### PR TITLE
fix MatplotlibDeprecationWarning for set_view/data_interval

### DIFF
--- a/backtrader/plot/locator.py
+++ b/backtrader/plot/locator.py
@@ -223,8 +223,8 @@ class AutoDateLocator(ADLocator):
 
         locator.set_axis(self.axis)
 
-        locator.set_view_interval(*self.axis.get_view_interval())
-        locator.set_data_interval(*self.axis.get_data_interval())
+        locator.axis.set_view_interval(*self.axis.get_view_interval())
+        locator.axis.set_data_interval(*self.axis.get_data_interval())
         return locator
 
 


### PR DESCRIPTION
Fixes these two warnings when creating a plot:

backtrader\plot\locator.py:226: MatplotlibDeprecationWarning: 
The set_view_interval function was deprecated in Matplotlib 3.5 and will be removed two minor releases later. Use `.Axis.set_view_interval` instead.

backtrader\plot\locator.py:227: MatplotlibDeprecationWarning: 
The set_data_interval function was deprecated in Matplotlib 3.5 and will be removed two minor releases later. Use `.Axis.set_data_interval` instead.